### PR TITLE
Skip analysis of file generated by mockery

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
 vendor
+
+# IDEs
+.idea/

--- a/imports_analyzer/analyzer.go
+++ b/imports_analyzer/analyzer.go
@@ -64,6 +64,13 @@ func (ci ConfiguredInspector) run(pass *analysis.Pass) (interface{}, error) {
 	forbiddenPaths := *ci.ForbiddenPathsRef
 
 	for _, f := range pass.Files {
+		fileName := pass.Fset.Position(f.Package).Filename
+
+		// TODO: Make this an argument like -skip-files and pass in CI job instead
+		if strings.HasSuffix(fileName, "internal/clients/google/google_mocks.go") {
+			continue
+		}
+
 		for _, imp := range f.Imports {
 			name := ""
 			if imp.Name != nil {


### PR DESCRIPTION
this will fix the build in https://github.com/sublime-security/go-mantis/pull/5630, which is [failing](https://github.com/sublime-security/go-mantis/actions/runs/9690922054/job/26741572512?pr=5630) on [this call](https://github.com/sublime-security/go-mantis/blob/c439e3f9e092e70d7162805b8fd27c6ecb18e33c/.github/workflows/go-tests.yml#L310)

i tested this by repro'ing the `import path "github.com/sublime-security/go-mantis/internal/log" cannot be named "log"` error in local, then verifying there was no longer an error with this version